### PR TITLE
Treat warnings as errors for source_files folder; address MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (MSVC)
   add_definitions("/wd4100")
 
   # warning level for edge specific source files 
-  set (EDGE_WARNING_LEVEL "/W4")
+  set (EDGE_WARNING_LEVEL /WX /W4)
 
   # To use the sanitizer with MSVC, you will need to either have your Visual Studio
   # or Build Tools install in your PATH variable, or copy the appropriate DLL to the program
@@ -139,9 +139,9 @@ else()
 
   # warning level for edge specific source files
   if (CLANG)
-    set (EDGE_WARNING_LEVEL -Wextra -Wunreachable-code-aggressive)
+    set (EDGE_WARNING_LEVEL -Wextra -Werror -Wunreachable-code-aggressive)
   else()
-    set (EDGE_WARNING_LEVEL -Wextra)
+    set (EDGE_WARNING_LEVEL -Wextra -Werror)
   endif()
 
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fno-exceptions -fno-strict-aliasing")

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -1513,13 +1513,8 @@ static void IdentifyVersion(void)
                         LogDebug("GAME BASE = [%s]\n", game_base.c_str());
                         return;
                     }
-                    else
-                        FatalError("IdentifyVersion: Could not identify '%s' as a valid "
-                                   "IWAD!\n",
-                                   fn.c_str());
                 }
             }
-            FatalError("IdentifyVersion: Unable to access specified '%s'", fn.c_str());
         }
         else
         {
@@ -1533,10 +1528,6 @@ static void IdentifyVersion(void)
                 LogDebug("GAME BASE = [%s]\n", game_base.c_str());
                 return;
             }
-            else
-                FatalError("IdentifyVersion: Could not identify '%s' as a valid "
-                           "IWAD!\n",
-                           fn.c_str());
         }
 
         // If we get here, try .epk and error out if we still can't access what
@@ -1563,10 +1554,6 @@ static void IdentifyVersion(void)
                         LogDebug("GAME BASE = [%s]\n", game_base.c_str());
                         return;
                     }
-                    else
-                        FatalError("IdentifyVersion: Could not identify '%s' as a valid "
-                                   "IWAD!\n",
-                                   fn.c_str());
                 }
             }
             FatalError("IdentifyVersion: Unable to access specified '%s'", fn.c_str());

--- a/source_files/edge/m_argv.cc
+++ b/source_files/edge/m_argv.cc
@@ -59,7 +59,6 @@ void ParseArguments(const int argc, const char *const *argv)
     EPI_UNUSED(argv);
 
     int       win_argc = 0;
-    size_t    i;
     wchar_t **win_argv = CommandLineToArgvW(GetCommandLineW(), &win_argc);
 
     if (!win_argv)
@@ -69,7 +68,7 @@ void ParseArguments(const int argc, const char *const *argv)
 
     std::vector<std::string> argv_block;
 
-    for (i = 0; i < win_argc; i++)
+    for (int i = 0; i < win_argc; i++)
     {
         EPI_ASSERT(win_argv[i] != nullptr);
         argv_block.push_back(epi::WStringToUTF8(win_argv[i]));
@@ -77,7 +76,7 @@ void ParseArguments(const int argc, const char *const *argv)
 
     LocalFree(win_argv);
 
-    for (i = 0; i < argv_block.size(); i++)
+    for (size_t i = 0; i < argv_block.size(); i++)
     {
         // Just place argv[0] as is
         if (i == 0)

--- a/source_files/edge/render/sokol/sokol_d3d11.cc
+++ b/source_files/edge/render/sokol/sokol_d3d11.cc
@@ -158,15 +158,6 @@ static inline HRESULT _sapp_dxgi_Present(IDXGISwapChain *self, UINT SyncInterval
 #endif
 }
 
-static inline HRESULT _sapp_dxgi_GetFrameStatistics(IDXGISwapChain *self, DXGI_FRAME_STATISTICS *pStats)
-{
-#if defined(__cplusplus)
-    return self->GetFrameStatistics(pStats);
-#else
-    return self->lpVtbl->GetFrameStatistics(self, pStats);
-#endif
-}
-
 static inline HRESULT _sapp_dxgi_SetMaximumFrameLatency(IDXGIDevice1 *self, UINT MaxLatency)
 {
 #if defined(__cplusplus)


### PR DESCRIPTION
This sets compiler warnings as errors for items in the source_files directory, as well as fixes some errors detected when building with MSVC. The unreachable code in e_mail was a side effect of the recent IdentifyVersion rework, but should now actually test both WAD and EPK extensions before failing.